### PR TITLE
Use cmp package instead of linking to cmp directly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "cmp"]
-	path = cmp
-	url = https://github.com/camgunz/cmp

--- a/package.yml
+++ b/package.yml
@@ -1,14 +1,11 @@
 depends:
     - test-runner
     - crc
+    - cmp
 
 source:
     - checksum_block.c
-    - cmp/cmp.c
     - serialization.c
-
-include_directories:
-    - cmp
 
 tests:
     - tests/block_checksum_tests.cpp

--- a/serialization.h
+++ b/serialization.h
@@ -8,7 +8,7 @@ extern "C" {
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include "cmp.h"
+#include <cmp/cmp.h>
 
 typedef struct {
     char *_block;

--- a/tests/serializer_tests.cpp
+++ b/tests/serializer_tests.cpp
@@ -3,7 +3,7 @@
 #include "../serialization.h"
 
 extern "C" {
-#include "cmp.h"
+#include "cmp/cmp.h"
 }
 
 TEST_GROUP(SerializerTestGroup)


### PR DESCRIPTION
Since we will be using MessagePack a lot, it makes sense to have a cmp module and make this one depend on it.
